### PR TITLE
Adding restriction to global hide function

### DIFF
--- a/addons/SA_AdvancedTowing/functions/fn_advancedTowingInit.sqf
+++ b/addons/SA_AdvancedTowing/functions/fn_advancedTowingInit.sqf
@@ -669,7 +669,9 @@ SA_Hint = {
 
 SA_Hide_Object_Global = {
 	params ["_obj"];
-	hideObjectGlobal _obj;
+	if( _obj isKindOf "Land_Can_V2_F" ) then {
+		hideObjectGlobal _obj;
+	};
 };
 
 SA_Set_Owner = {


### PR DESCRIPTION
Adding restriction that only objects of type Land_Can_V2_F can be hidden via the SA_Hide_Object_Global function. fixes #17