### PR TITLE
Detach helper object before deletion

### DIFF
--- a/addons/SA_AdvancedTowing/functions/fn_advancedTowingInit.sqf
+++ b/addons/SA_AdvancedTowing/functions/fn_advancedTowingInit.sqf
@@ -409,6 +409,7 @@ SA_Pickup_Tow_Ropes = {
 			{
 				_attachedObj ropeDetach _x;
 			} forEach (_vehicle getVariable ["SA_Tow_Ropes",[]]);
+			detach _attachedObj;
 			deleteVehicle _attachedObj;
 		} forEach ropeAttachedObjects _vehicle;
 		_helper = "Land_Can_V2_F" createVehicle position _player;


### PR DESCRIPTION
When ropes are picked up from towed vehicle the helper object is removed but it is not detached before.

This results in that every attach-detach of the ropes `attachedObjects` will return more `objNull`s. Detaching of helper object before deletion fixes this issue.